### PR TITLE
Fix release command issue being run in a subdirectory

### DIFF
--- a/news/24.bugfix
+++ b/news/24.bugfix
@@ -1,0 +1,1 @@
+Fix release command issue due to settings guessing the wrong path to the top-level towncrier.toml file when run from a subdirectory. @ericof

--- a/src/repoplone/settings/__init__.py
+++ b/src/repoplone/settings/__init__.py
@@ -79,18 +79,20 @@ def get_settings() -> t.RepositorySettings:
     """Return base settings."""
     cwd_path = get_cwd_path()
     raw_settings = _get_raw_settings(cwd_path)
-    root_path = raw_settings.repository.__root__
+    root_path: Path = raw_settings.repository.__root__
     name = raw_settings.repository.name
     root_changelog = root_path / raw_settings.repository.changelog
     version_path = root_path / raw_settings.repository.version
     version = version_path.read_text().strip()
     version_format = raw_settings.repository.get("version_format", "semver")
     compose_path = _get_compose_path(root_path, raw_settings)
-    repository_towncrier = raw_settings.repository.get("towncrier", {})
+    repository_towncrier: dict = raw_settings.repository.get("towncrier", {})
     backend = utils.get_backend(root_path, raw_settings)
     managed_by_uv = backend.managed_by_uv
     frontend = utils.get_frontend(root_path, raw_settings)
-    towncrier = utils.get_towncrier_settings(backend, frontend, repository_towncrier)
+    towncrier = utils.get_towncrier_settings(
+        root_path, backend, frontend, repository_towncrier
+    )
     changelogs = utils.get_changelogs(root_changelog, backend, frontend)
     remote_origin = git_utils.remote_origin(root_path)
     return t.RepositorySettings(

--- a/src/repoplone/utils/__init__.py
+++ b/src/repoplone/utils/__init__.py
@@ -18,18 +18,19 @@ def get_changelogs(
 
 
 def get_towncrier_settings(
-    backend: t.Package, frontend: t.Package, repository: dict
+    root_path: Path, backend: t.Package, frontend: t.Package, repository: dict
 ) -> t.TowncrierSettings:
     sections = []
     raw_sections = [
-        ("backend", "Backend", backend.towncrier),
-        ("frontend", "Frontend", frontend.towncrier),
+        ("backend", "Backend", root_path / backend.towncrier),
+        ("frontend", "Frontend", root_path / frontend.towncrier),
     ]
-    if repository:
+    if repository and (towncrier := repository.get("settings", "")):
+        path: Path = root_path / towncrier
         section = (
             "repository",
             repository["section"],
-            Path(repository["settings"]).resolve(),
+            path.resolve(),
         )
         raw_sections.append(section)
     sections = [t.TowncrierSection(*info) for info in raw_sections]

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -71,6 +71,31 @@ def test_internal_project_packages(test_internal_project, bust_path_cache):
 
 
 @pytest.mark.parametrize(
+    "idx,section_id,exists",
+    [
+        (0, "backend", True),
+        (1, "frontend", True),
+        (2, "repository", True),
+    ],
+)
+def test_settings_from_subdirectory(
+    test_internal_project_from_distribution,
+    monkeypatch,
+    bust_path_cache,
+    idx: int,
+    section_id: str,
+    exists: bool,
+):
+    monkeypatch.chdir(test_internal_project_from_distribution / "backend")
+    result = settings.get_settings()
+    assert result.root_path == test_internal_project_from_distribution
+    sections = result.towncrier.sections
+    section = sections[idx]
+    assert section.section_id == section_id
+    assert section.path.exists() is exists
+
+
+@pytest.mark.parametrize(
     "path,expected_warnings,message",
     [
         [


### PR DESCRIPTION
Due to settings guessing the wrong path to the top-level towncrier.toml file when run from a subdirectory, the root changelog was not being generated.

Fixes #24
