### PR TITLE
Show resolved version in next_version confirmation prompt.

### DIFF
--- a/news/62.bugfix
+++ b/news/62.bugfix
@@ -1,0 +1,1 @@
+Fixed the bump confirmation in the `next_version` release step to display the resolved target version instead of the raw user input — previously a segment like `a` or an empty string (for calver) would leak into the confirmation prompt. @ericof

--- a/src/repoplone/release/steps/version.py
+++ b/src/repoplone/release/steps/version.py
@@ -57,9 +57,10 @@ def step_next_version(
         dutils.print(error)
         status = False
     elif not prompted:
+        next_version = next_version or state.next_version
         # Confirm the version if it was not prompted
         dutils.indented_print(
-            f"- Bump version from {settings.version} to {state.next_version}"
+            f"- Bump version from {settings.version} to {next_version}"
         )
         status = dutils.check_confirm()
     else:

--- a/tests/release/test_version_step.py
+++ b/tests/release/test_version_step.py
@@ -1,0 +1,104 @@
+"""Regression tests for the ``next_version`` step display bug (#62).
+
+Before the fix, ``step_next_version`` showed ``state.next_version`` (the raw
+user input — e.g. ``"a"``, ``"minor"``, or ``""`` for calver) in the bump
+confirmation prompt instead of the version returned by
+``_get_next_version``. These tests capture the displayed text and assert it
+contains the resolved version.
+"""
+
+from repoplone.release import _types as t
+from repoplone.release.steps.version import step_next_version
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def fake_settings():
+    return SimpleNamespace(version="1.0.0b11")
+
+
+@pytest.fixture
+def captured_output(monkeypatch):
+    """Mock display + confirmation; return list of indented_print calls."""
+    captured: list[str] = []
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.dutils.indented_print",
+        lambda text: captured.append(text),
+    )
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.dutils.check_confirm",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.dutils.print",
+        lambda *args, **kwargs: None,
+    )
+    return captured
+
+
+@pytest.fixture
+def stub_resolution(monkeypatch):
+    """Patch the version-resolution boundary; tests pick the resolved value."""
+
+    def _stub(resolved: str):
+        monkeypatch.setattr(
+            "repoplone.release.steps.version.vutils.next_version",
+            lambda desired, current: resolved,
+        )
+        monkeypatch.setattr(
+            "repoplone.release.steps.version.utils.valid_next_version",
+            lambda settings, version: True,
+        )
+
+    return _stub
+
+
+def test_segment_input_shows_resolved_version_in_confirmation(
+    fake_settings, captured_output, stub_resolution
+):
+    stub_resolution("1.0.0a0")
+    state = t.PipelineState(
+        version_format="semver",
+        original_version="1.0.0b11",
+        next_version="a",
+    )
+
+    ok = step_next_version("version", "Next version", fake_settings, state)
+
+    assert ok is True
+    assert any("to 1.0.0a0" in line for line in captured_output), captured_output
+    assert not any(line.rstrip().endswith(" to a") for line in captured_output)
+
+
+def test_calver_empty_input_shows_computed_version_in_confirmation(
+    fake_settings, captured_output, stub_resolution
+):
+    stub_resolution("20260213.1")
+    state = t.PipelineState(
+        version_format="calver",
+        original_version="20260213.0",
+        next_version="",
+    )
+
+    ok = step_next_version("version", "Next version", fake_settings, state)
+
+    assert ok is True
+    assert any("to 20260213.1" in line for line in captured_output), captured_output
+    assert not any(line.rstrip().endswith(" to ") for line in captured_output)
+
+
+def test_state_is_updated_with_resolved_version_after_confirmation(
+    fake_settings, captured_output, stub_resolution
+):
+    stub_resolution("1.0.0a0")
+    state = t.PipelineState(
+        version_format="semver",
+        original_version="1.0.0b11",
+        next_version="a",
+    )
+
+    step_next_version("version", "Next version", fake_settings, state)
+
+    assert state.next_version == "1.0.0a0"


### PR DESCRIPTION
## Summary

- Fix `step_next_version` so the bump confirmation shows the **resolved** target version instead of the raw user input.
- Before this PR, running `uvx repoplone release a` displayed `Bump version from 1.0.0b11 to a`, and a calver release with no argument displayed `Bump version from 20260213.0 to ` (trailing blank).

## Root cause

The "not prompted" branch interpolated `state.next_version` (the desired-version argument the user passed — e.g. a segment like `"a"`, `"minor"`, or `""` for calver) into the confirmation message. The resolved value was only written back to `state.next_version` *after* the confirmation, so users saw whatever they typed (or an empty string).

## Fix

Use the local `next_version` returned by `_get_next_version()` for the display string. One-line change in [src/repoplone/release/steps/version.py](src/repoplone/release/steps/version.py).

## Tests

Three regression tests in `tests/release/test_version_step.py`:

- `test_segment_input_shows_resolved_version_in_confirmation` — segment `"a"` is supplied, confirmation must show `1.0.0a0`, not `a`.
- `test_calver_empty_input_shows_computed_version_in_confirmation` — calver mode with empty input must show the computed date version, not a trailing blank.
- `test_state_is_updated_with_resolved_version_after_confirmation` — `state.next_version` is rewritten with the resolved value after a successful confirm.

Verified that all three regression tests fail against the pre-fix code (the first two with the buggy display strings, the third already passed) and pass with the fix.

## Test plan

- [ ] `make test` — full suite (325, 3 new) passes locally.
- [ ] `make check` — ruff format + lint + mypy + pyroma all clean locally.
- [ ] In a real Plone monorepo, run `uvx repoplone release a --dry-run` and confirm the bump prompt shows the resolved alpha version (e.g. `1.0.0a1`).
- [ ] In a calver project, run `uvx repoplone release --dry-run` and confirm the bump prompt shows the computed date version.
- [ ] CI (Python 3.10–3.14) passes.

Closes #62.