### PR TITLE
Exclude existing pins from tool.uv.constraint-dependencies output

### DIFF
--- a/news/68.bugfix
+++ b/news/68.bugfix
@@ -1,0 +1,1 @@
+Fixed `tool.uv.constraint-dependencies` regeneration so packages already pinned in `project.dependencies`, `project.optional-dependencies`, `dependency-groups`, or `tool.uv.override-dependencies` are no longer duplicated in the constraints list — each package now appears in a single location. @ericof

--- a/src/repoplone/utils/dependencies/constraints.py
+++ b/src/repoplone/utils/dependencies/constraints.py
@@ -73,13 +73,26 @@ def get_base_constraints(package_name: str, version: str) -> list[str]:
 def get_package_constraints(
     package_name: str, version: str, existing_pins: t.Requirements
 ) -> list[str]:
-    """Return plone constraints for a version."""
+    """Return package constraints for a version, excluding packages already pinned.
+
+    Packages declared in ``project.dependencies``,
+    ``project.optional-dependencies``, ``dependency-groups`` or
+    ``tool.uv.override-dependencies`` are skipped so each package appears only
+    once in the final ``pyproject.toml``.
+    """
     versions = pypi_package_versions(package_name)
-    existing_constraints = [
-        str(v) for k, v in existing_pins.items() if k != package_name
-    ]
     if version not in versions:
         raise RuntimeError(f"{package_name} {version} not available.")
-
+    excluded = {
+        canonicalize_name(name) for name in existing_pins if name != package_name
+    }
     constraints = get_base_constraints(package_name, version)
-    return parse_constraints(constraints, existing_constraints)
+    filtered: list[str] = []
+    for line in constraints:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if canonicalize_name(Requirement(stripped).name) in excluded:
+            continue
+        filtered.append(stripped)
+    return sorted(filtered, key=lambda line: canonicalize_name(Requirement(line).name))

--- a/src/repoplone/utils/dependencies/pyproject.py
+++ b/src/repoplone/utils/dependencies/pyproject.py
@@ -15,13 +15,30 @@ PYTHON_VERSION_PATTERN = re.compile(r"^Programming Language :: Python :: (\d+\.\
 LICENSE_PATTERN = re.compile(r"^License :: (.+)$")
 
 
+def _get_table(data: tomlkit.TOMLDocument | items.Table, key: str) -> items.Table:
+    """Return the current project information."""
+    table = data[key]
+    if not isinstance(table, items.Table | container.OutOfOrderTableProxy):
+        raise ValueError("Invalid data")
+    return table
+
+
+def _get_project_table(data: tomlkit.TOMLDocument) -> items.Table:
+    """Return the current project information."""
+    return _get_table(data, "project")
+
+
 def _process_requirements(data: tomlkit.TOMLDocument, key: str) -> list[Requirement]:
     requirements: list[Requirement] = []
-    raw_dependencies: items.Table | items.Array = (
-        _get_project_table(data).get(key.split(".")[-1])
-        if key.startswith("project")
-        else data.get(key)
-    ) or tomlkit.table()
+    base_table = data
+    try:
+        for part in key.split(".")[:-1]:
+            base_table = base_table.get(part, {})
+        raw_dependencies: items.Table | items.Array = (
+            base_table.get(key.split(".")[-1])
+        ) or tomlkit.table()
+    except (KeyError, ValueError):
+        raw_dependencies = tomlkit.array()
     if isinstance(raw_dependencies, items.Array):
         tmp_table = tomlkit.table()
         tmp_table.add(key, raw_dependencies)
@@ -31,14 +48,6 @@ def _process_requirements(data: tomlkit.TOMLDocument, key: str) -> list[Requirem
             for value in group_values:
                 requirements.append(Requirement(value))
     return requirements
-
-
-def _get_project_table(data: tomlkit.TOMLDocument) -> items.Table:
-    """Return the current project information."""
-    project = data["project"]
-    if not isinstance(project, items.Table | container.OutOfOrderTableProxy):
-        raise ValueError("Invalid data")
-    return project
 
 
 def _get_uv_table(data: tomlkit.TOMLDocument) -> items.Table:
@@ -64,6 +73,7 @@ def get_all_pinned_dependencies(data: tomlkit.TOMLDocument) -> t.Requirements:
         "project.dependencies",
         "project.optional-dependencies",
         "dependency-groups",
+        "tool.uv.override-dependencies",
     ):
         raw_dependencies.extend(_process_requirements(data, key))
     dependencies: t.Requirements = {

--- a/tests/_resources/pyproject/overrides.toml
+++ b/tests/_resources/pyproject/overrides.toml
@@ -1,0 +1,7 @@
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["Products.CMFPlone==6.1.0"]
+
+[tool.uv]
+override-dependencies = ["urllib3==2.0.0", "pytest-plone==1.0.0"]

--- a/tests/utils/dependencies/test_utils_constraints.py
+++ b/tests/utils/dependencies/test_utils_constraints.py
@@ -24,12 +24,21 @@ def existing_pins(pyproject_toml) -> t.Requirements:
 
 
 @pytest.mark.parametrize(
-    "core_package,core_package_version,constraint",
+    "core_package,core_package_version,constraint,is_present",
     [
-        ["Products.CMFPlone", "6.1.0", "Products.CMFPlone==6.1.0"],
-        ["Products.CMFPlone", "6.1.0", "pytest-plone>=1.0.0a1"],
-        ["kitconcept.intranet", "1.0.0a17", "kitconcept.voltolighttheme==6.0.0a21"],
-        ["kitconcept.intranet", "1.0.0a17", "pytest-plone>=1.0.0a1"],
+        # Package being upgraded — kept (filtered out of existing_pins)
+        ["Products.CMFPlone", "6.1.0", "Products.CMFPlone==6.1.0", True],
+        # Already pinned in dependency-groups locally — excluded
+        ["Products.CMFPlone", "6.1.0", "pytest-plone>=1.0.0a1", False],
+        # Upstream-pinned, not locally pinned — kept
+        [
+            "kitconcept.intranet",
+            "1.0.0a17",
+            "kitconcept.voltolighttheme==6.0.0a21",
+            True,
+        ],
+        # Already pinned in dependency-groups locally — excluded
+        ["kitconcept.intranet", "1.0.0a17", "pytest-plone>=1.0.0a1", False],
     ],
 )
 @pytest.mark.vcr()
@@ -38,10 +47,55 @@ def test_get_package_constraints(
     core_package: str,
     core_package_version: str,
     constraint: str,
+    is_present: bool,
 ):
     func = const_utils.get_package_constraints
     result = func(core_package, core_package_version, existing_pins)
-    assert constraint in result
+    assert (constraint in result) is is_present
+
+
+def test_get_package_constraints_excludes_existing_pins(monkeypatch):
+    """Existing pins (including override-dependencies) must not appear in output."""
+    from repoplone.utils.dependencies import pyproject as pyproject_utils
+
+    src = """
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["Products.CMFPlone==6.1.0"]
+
+[tool.uv]
+override-dependencies = ["urllib3==2.0.0"]
+"""
+    data = tomlkit.parse(src)
+    existing_pins = pyproject_utils.get_all_pinned_dependencies(data)
+
+    monkeypatch.setattr(
+        const_utils,
+        "pypi_package_versions",
+        lambda name: ["6.1.0"],
+    )
+    monkeypatch.setattr(
+        const_utils,
+        "get_base_constraints",
+        lambda name, version: [
+            "Products.CMFPlone==6.1.0",
+            "urllib3==1.9.0",
+            "requests==2.32.3",
+        ],
+    )
+
+    result = const_utils.get_package_constraints(
+        "Products.CMFPlone", "6.1.0", existing_pins
+    )
+
+    # Excluded — present in override-dependencies
+    assert "urllib3==1.9.0" not in result
+    assert not any(line.startswith("urllib3") for line in result)
+    # Kept — the package being upgraded
+    assert "Products.CMFPlone==6.1.0" in result
+    # Kept — not pinned anywhere locally
+    assert "requests==2.32.3" in result
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/dependencies/test_utils_pyproject.py
+++ b/tests/utils/dependencies/test_utils_pyproject.py
@@ -16,6 +16,12 @@ def pyproject_toml(pyproject_path) -> tomlkit.TOMLDocument:
     return tomlkit.parse(pyproject_path.read_text())
 
 
+@pytest.fixture
+def pyproject_overrides(get_resource_file) -> tomlkit.TOMLDocument:
+    pyproject_path = get_resource_file("pyproject/overrides.toml")
+    return tomlkit.parse(pyproject_path.read_text())
+
+
 @pytest.mark.parametrize(
     "key,total_items",
     [
@@ -33,6 +39,22 @@ def test__process_requirements(pyproject_toml, key: str, total_items: int):
         assert {isinstance(item, Requirement) for item in result} == {True}
 
 
+def test__process_requirements_tool_uv_override_dependencies(pyproject_overrides):
+    result = pyproject_utils._process_requirements(
+        pyproject_overrides, "tool.uv.override-dependencies"
+    )
+    assert len(result) == 2
+    assert {req.name for req in result} == {"urllib3", "pytest-plone"}
+
+
+def test__process_requirements_missing_path_returns_empty():
+    data = tomlkit.parse('[project]\nname = "demo"\n')
+    result = pyproject_utils._process_requirements(
+        data, "tool.uv.override-dependencies"
+    )
+    assert result == []
+
+
 @pytest.mark.parametrize(
     "package,expected",
     [
@@ -45,6 +67,16 @@ def test_get_all_pinned_dependencies(pyproject_toml, package: str, expected: str
     result = func(pyproject_toml)
     assert package in result
     assert result[package].specifier == expected
+
+
+def test_get_all_pinned_dependencies_includes_override_dependencies(
+    pyproject_overrides,
+):
+    result = pyproject_utils.get_all_pinned_dependencies(pyproject_overrides)
+    assert "urllib3" in result
+    assert str(result["urllib3"].specifier) == "==2.0.0"
+    assert "pytest-plone" in result
+    assert str(result["pytest-plone"].specifier) == "==1.0.0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Packages already pinned in `project.dependencies`, `project.optional-dependencies`, `dependency-groups`, or `tool.uv.override-dependencies` are no longer duplicated in `tool.uv.constraint-dependencies`. Each package now appears in a single location.

Closes #68

## Why

Previously, `repoplone` would regenerate `constraint-dependencies` by merging upstream constraints with the project's existing pins — which left the same package in *both* `project.dependencies` and `constraint-dependencies`, and could even leave a stale value in `constraint-dependencies` next to an authoritative one in `tool.uv.override-dependencies`. Whichever wins at solve time, the duplicated entry is misleading noise in the file and could lead to an impossible resolution by `uv`.

## Changes

- [src/repoplone/utils/dependencies/pyproject.py](src/repoplone/utils/dependencies/pyproject.py):
  - Generalized `_process_requirements` to traverse arbitrary dotted key paths (needed to reach `tool.uv.override-dependencies`).
  - `get_all_pinned_dependencies` now also reads `tool.uv.override-dependencies`.
- [src/repoplone/utils/dependencies/constraints.py](src/repoplone/utils/dependencies/constraints.py):
  - `get_package_constraints` now **excludes** any package whose canonical name is in `existing_pins` (other than the package being upgraded) from the returned constraints list. Skips comments and blank lines on the way through.
  - `parse_constraints` is **unchanged** — it's still used inside `_get_uv_constraints` to merge an upstream project's `dependencies` + `constraint-dependencies` into a complete upstream pin set, where preserve-semantics are the right behavior.

## Test plan

- [x] `make test` — 354 passed.
- [x] `make lint` — ruff + pyroma 10/10 + check-python-versions + mypy clean.
- [x] New offline test `test_get_package_constraints_excludes_existing_pins` monkeypatches the network paths and verifies a package in `tool.uv.override-dependencies` is excluded from the output, while the upgrade target and non-pinned upstream constraints are kept.
- [x] New `tests/_resources/pyproject/overrides.toml` fixture drives focused tests for `_process_requirements` and `get_all_pinned_dependencies` against `tool.uv.override-dependencies`.
- [x] Existing VCR-backed `test_get_package_constraints` parametrize gained an `is_present` boolean; `pytest-plone>=1.0.0a1` now asserts **not present** in output (it's already pinned via `dependency-groups`).