### PR TITLE
Case-insensitive deps components (#78) and restartable releases via --start-step (#79)

### DIFF
--- a/news/78.bugfix
+++ b/news/78.bugfix
@@ -1,0 +1,1 @@
+Accept component names case-insensitively in `deps upgrade`, `deps sync` and `deps constraints`. @ericof

--- a/news/79.feature
+++ b/news/79.feature
@@ -1,0 +1,1 @@
+Add a `--start-step` option to `repoplone release` to restart a release from a given step, skipping the earlier (already completed) ones. @ericof

--- a/src/repoplone/commands/dependencies/__init__.py
+++ b/src/repoplone/commands/dependencies/__init__.py
@@ -43,12 +43,10 @@ def check(ctx: typer.Context):
         {"header": "Latest Version"},
     ]
     rows = []
-    if settings.backend.enabled:
-        backend_versions = dependencies.check_backend_base_package(settings)
-        rows.append(["Backend", *backend_versions])
-    if settings.frontend.enabled:
-        frontend_versions = dependencies.check_frontend_base_package(settings)
-        rows.append(["Frontend", *frontend_versions])
+    for name, (check_func, _) in UPGRADE_FUNC.items():
+        if getattr(settings, name).enabled:
+            versions = check_func(settings)
+            rows.append([name.title(), *versions])
     table = dutils.table(title, cols, rows)
     dutils.print(table)
 
@@ -104,7 +102,8 @@ def constraints(
 ):
     """Update constraints for a specific component."""
     settings: t.RepositorySettings = ctx.obj.settings
-    if component not in ("backend"):
+    component = component.lower()
+    if component != "backend":
         typer.echo("Component must be 'backend'.")
         raise typer.Exit(1)
     managed_by_uv = settings.backend.managed_by_uv
@@ -132,6 +131,7 @@ def sync(
 ):
     """Sync the lockfile for a specific component."""
     settings: t.RepositorySettings = ctx.obj.settings
+    component = component.lower()
     if component not in ("backend", "frontend", "both"):
         typer.echo("Component must be either 'backend' or 'frontend'.")
         raise typer.Exit(1)
@@ -176,6 +176,8 @@ def upgrade(
 ):
     """Upgrade a base dependency to a newer version."""
     settings: t.RepositorySettings = ctx.obj.settings
+    # Accept both lowercase and uppercase component names
+    component = component.lower()
     if component not in ("backend", "frontend"):
         typer.echo("Component must be either 'backend' or 'frontend'.")
         raise typer.Exit(1)

--- a/src/repoplone/commands/release.py
+++ b/src/repoplone/commands/release.py
@@ -48,13 +48,27 @@ def main(
         ),
     ] = NO_VERSION,
     dry_run: Annotated[bool, typer.Option(help="Is this a dry run?")] = False,
+    start_step: Annotated[
+        str,
+        typer.Option(
+            "--start-step",
+            help=(
+                "Restart the release from this step id, skipping earlier steps. "
+                "Requires a concrete version when the version step is skipped."
+            ),
+        ),
+    ] = "",
 ):
     """Release the packages in this repository."""
     settings: t.RepositorySettings = ctx.obj.settings
     dutils.print(f"\n[bold green]Release {settings.name}[/bold green]")
     if not _preflight_check(settings):
         raise typer.Exit(0)
-    pipeline = ReleasePipeline(settings, dry_run, desired_version)
+    try:
+        pipeline = ReleasePipeline(settings, dry_run, desired_version, start_step)
+    except ValueError as e:
+        dutils.print(f"\n[bold red]{e}[/bold red]")
+        raise typer.Exit(1) from e
     try:
         pipeline()
     except RuntimeError as e:

--- a/src/repoplone/release/pipeline.py
+++ b/src/repoplone/release/pipeline.py
@@ -1,9 +1,28 @@
 from repoplone._types import RepositorySettings
 from repoplone.release import _types as t
+from repoplone.release.steps.version import resolve_skipped_version
 from repoplone.utils import display as dutils
 
 
 NO_VERSION: str = "next"
+
+
+def resolve_start(steps: list[t.PipelineReleaseStep], start_step: str) -> int:
+    """Return the 0-based index of ``start_step`` within ``steps``.
+
+    :param steps: resolved release steps for the repository.
+    :param start_step: id of the step to restart from; empty means start from
+        the beginning.
+    :returns: index into ``steps`` of the first step to execute.
+    :raises ValueError: if ``start_step`` is not a known step id.
+    """
+    if not start_step:
+        return 0
+    ids = [step.id for step in steps]
+    if start_step not in ids:
+        valid = ", ".join(ids)
+        raise ValueError(f"Unknown start step {start_step!r}. Valid steps: {valid}.")
+    return ids.index(start_step)
 
 
 class ReleasePipeline:
@@ -17,6 +36,7 @@ class ReleasePipeline:
         settings: RepositorySettings,
         dry_run: bool = False,
         desired_version: str = "",
+        start_step: str = "",
     ) -> None:
         # Populate steps from settings (parsed from [repository.release])
         self.steps = []
@@ -33,6 +53,15 @@ class ReleasePipeline:
         original_version = settings.version
         version_format = settings.version_format
         desired_version = desired_version if desired_version != NO_VERSION else ""
+        # Restart support: skip every step before ``start_step``
+        self.start_index = resolve_start(self.steps, start_step)
+        skipped_ids = {step.id for step in self.steps[: self.start_index]}
+        if "version" in skipped_ids:
+            # The version step is skipped, so resolve and validate the version
+            # supplied on the command line in its place.
+            desired_version = resolve_skipped_version(
+                settings, original_version, desired_version
+            )
         # State
         self.state = t.PipelineState(
             dry_run=dry_run,
@@ -49,6 +78,14 @@ class ReleasePipeline:
         # Run release steps
         for step_index, step in enumerate(self.steps, start=1):
             state.steps_current = step_index
+            if step_index <= self.start_index:
+                # Step precedes the requested start step: treat it as already
+                # completed in a previous run and skip its execution.
+                dutils.print(
+                    f"\n[dim]{step_index:02d}/{state.steps_total:02d} "
+                    f"{step.title} (skipped)[/dim]"
+                )
+                continue
             dutils.print(
                 f"\n[bold green]{step_index:02d}/{state.steps_total:02d}[/bold green] "
                 f"[bold]{step.title}[/bold]"

--- a/src/repoplone/release/steps/version.py
+++ b/src/repoplone/release/steps/version.py
@@ -22,6 +22,31 @@ def _get_next_version(
     return next_version, error
 
 
+def resolve_skipped_version(
+    settings: t.RepositorySettings, original_version: str, desired_version: str
+) -> str:
+    """Resolve and validate the next version when the ``version`` step is skipped.
+
+    Mirrors the non-interactive resolution of :func:`step_next_version` so a
+    restart that skips the version step still validates the supplied version,
+    rejecting invalid values and versions already tagged in Git.
+
+    :param settings: repository settings.
+    :param original_version: current version of the repository.
+    :param desired_version: version supplied on the command line.
+    :returns: the validated next version.
+    :raises ValueError: if no version was supplied or it is invalid.
+    """
+    if not desired_version:
+        raise ValueError(
+            "A concrete version is required when restarting past the 'version' step."
+        )
+    next_version, error = _get_next_version(settings, original_version, desired_version)
+    if error:
+        raise ValueError(error)
+    return next_version
+
+
 def _prompt_version_semver(original_version: str, state: t.PipelineState) -> str:
     """Prompt the user for the next version."""
     prompt_message = "\n   [bold]Select the next version[/bold]"

--- a/tests/commands/release/test_release.py
+++ b/tests/commands/release/test_release.py
@@ -34,6 +34,7 @@ def test_release_help(bust_path_cache, test_public_project):
     output = result.stdout
     assert "release [OPTIONS] [DESIRED_VERSION] COMMAND" in output
     assert "Could be the version" in output
+    assert "--start-step" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/commands/release/test_release.py
+++ b/tests/commands/release/test_release.py
@@ -34,7 +34,21 @@ def test_release_help(bust_path_cache, test_public_project):
     output = result.stdout
     assert "release [OPTIONS] [DESIRED_VERSION] COMMAND" in output
     assert "Could be the version" in output
-    assert "--start-step" in output
+
+
+def test_release_defines_start_step_option():
+    """The release command exposes ``--start-step``.
+
+    Introspect the command parameters rather than the rendered ``--help`` text,
+    which Rich wraps/colours differently depending on terminal width.
+    """
+    import typer
+
+    from repoplone.commands.release import app as release_app
+
+    cmd = typer.main.get_command(release_app)
+    flags = [opt for param in cmd.params for opt in getattr(param, "opts", [])]
+    assert "--start-step" in flags
 
 
 @pytest.mark.parametrize(

--- a/tests/release/test_pipeline.py
+++ b/tests/release/test_pipeline.py
@@ -35,3 +35,105 @@ def test_pipeline_state(settings, dry_run: bool, desired_version: str):
     assert state.version_format == settings.version_format
     assert state.steps_current == 0
     assert state.steps_total == 8
+
+
+STEP_IDS = [
+    "changelog",
+    "version",
+    "repository",
+    "release_backend",
+    "release_frontend",
+    "git",
+    "gh_release",
+    "bye",
+]
+
+
+def _step(step_id: str) -> t.PipelineReleaseStep:
+    return t.PipelineReleaseStep(id=step_id, title=step_id, func=lambda *a, **k: True)
+
+
+def _recording_steps(
+    steps: list[t.PipelineReleaseStep], calls: list[str]
+) -> list[t.PipelineReleaseStep]:
+    """Clone ``steps`` replacing each func with one that records its id."""
+
+    def make(step_id: str):
+        def func(sid, title, settings, state, **kwargs):
+            calls.append(sid)
+            return True
+
+        return func
+
+    return [
+        t.PipelineReleaseStep(id=s.id, title=s.title, func=make(s.id)) for s in steps
+    ]
+
+
+def test_resolve_start_empty_returns_zero():
+    assert pipeline.resolve_start([_step(i) for i in STEP_IDS], "") == 0
+
+
+@pytest.mark.parametrize(
+    "start_step,expected", [("changelog", 0), ("version", 1), ("git", 5), ("bye", 7)]
+)
+def test_resolve_start_returns_index(start_step: str, expected: int):
+    assert pipeline.resolve_start([_step(i) for i in STEP_IDS], start_step) == expected
+
+
+def test_resolve_start_unknown_raises():
+    steps = [_step(i) for i in STEP_IDS]
+    with pytest.raises(ValueError, match="Unknown start step 'nope'"):
+        pipeline.resolve_start(steps, "nope")
+    # The error lists the valid ids to guide the user.
+    with pytest.raises(ValueError, match="changelog"):
+        pipeline.resolve_start(steps, "nope")
+
+
+def test_pipeline_skips_steps_before_start(settings, monkeypatch):
+    """Steps before ``start_step`` are skipped but the pipeline still succeeds."""
+    captured: list[str] = []
+    monkeypatch.setattr(
+        pipeline.dutils, "print", lambda *a, **k: captured.append(a[0] if a else "")
+    )
+    p = pipeline.ReleasePipeline(settings=settings, start_step="version")
+    calls: list[str] = []
+    p.steps = _recording_steps(p.steps, calls)
+
+    assert p() is True
+    assert "changelog" not in calls
+    assert calls == STEP_IDS[1:]
+    # steps_total stays the full pipeline length; skipped step is marked as such.
+    assert p.state.steps_total == 8
+    skipped = [line for line in captured if "(skipped)" in line]
+    assert len(skipped) == 1
+    assert "Display Changelog" in skipped[0]
+
+
+def test_pipeline_skips_version_with_supplied_version(settings, monkeypatch):
+    """Restarting past ``version`` resolves the supplied version in its place."""
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.vutils.next_version",
+        lambda desired, current: "1.0.0a1",
+    )
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.utils.valid_next_version",
+        lambda settings, version: True,
+    )
+    monkeypatch.setattr(pipeline.dutils, "print", lambda *a, **k: None)
+
+    p = pipeline.ReleasePipeline(
+        settings=settings, desired_version="1.0.0a1", start_step="git"
+    )
+    assert p.state.next_version == "1.0.0a1"
+
+    calls: list[str] = []
+    p.steps = _recording_steps(p.steps, calls)
+    assert p() is True
+    assert calls == ["git", "gh_release", "bye"]
+
+
+def test_pipeline_skip_version_requires_version(settings):
+    """Skipping ``version`` without a concrete version is rejected."""
+    with pytest.raises(ValueError, match="concrete version"):
+        pipeline.ReleasePipeline(settings=settings, start_step="git")

--- a/tests/release/test_version_step.py
+++ b/tests/release/test_version_step.py
@@ -8,6 +8,7 @@ contains the resolved version.
 """
 
 from repoplone.release import _types as t
+from repoplone.release.steps.version import resolve_skipped_version
 from repoplone.release.steps.version import step_next_version
 from types import SimpleNamespace
 
@@ -102,3 +103,40 @@ def test_state_is_updated_with_resolved_version_after_confirmation(
     step_next_version("version", "Next version", fake_settings, state)
 
     assert state.next_version == "1.0.0a0"
+
+
+def test_resolve_skipped_version_returns_validated(fake_settings, stub_resolution):
+    """A segment input is resolved and returned when the step is skipped."""
+    stub_resolution("1.0.0a0")
+    assert resolve_skipped_version(fake_settings, "1.0.0b11", "a") == "1.0.0a0"
+
+
+def test_resolve_skipped_version_requires_version(fake_settings):
+    """An empty version is rejected with a clear message."""
+    with pytest.raises(ValueError, match="concrete version is required"):
+        resolve_skipped_version(fake_settings, "1.0.0b11", "")
+
+
+def test_resolve_skipped_version_rejects_invalid(fake_settings, monkeypatch):
+    """An unparseable version surfaces the resolution error."""
+
+    def _raise(desired, current):
+        raise ValueError("bad")
+
+    monkeypatch.setattr("repoplone.release.steps.version.vutils.next_version", _raise)
+    with pytest.raises(ValueError, match="Invalid version"):
+        resolve_skipped_version(fake_settings, "1.0.0b11", "bogus")
+
+
+def test_resolve_skipped_version_rejects_existing_tag(fake_settings, monkeypatch):
+    """A version already tagged in Git is rejected."""
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.vutils.next_version",
+        lambda desired, current: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "repoplone.release.steps.version.utils.valid_next_version",
+        lambda settings, version: False,
+    )
+    with pytest.raises(ValueError, match="already exists as a tag"):
+        resolve_skipped_version(fake_settings, "1.0.0b11", "1.0.0")

--- a/tests/test_monorepo_variants.py
+++ b/tests/test_monorepo_variants.py
@@ -106,6 +106,61 @@ def test_frontend_only_deps_upgrade_backend_error(
     assert "Error: Backend component is not enabled" in result.stdout
 
 
+@pytest.mark.parametrize("component", ["FRONTEND", "Frontend", "FrOnTeNd"])
+def test_deps_upgrade_component_case_insensitive(
+    test_backend_only_project, bust_path_cache, runner, component
+):
+    """Mixed-case component names are normalized before validation.
+
+    Reaching the "not enabled" gate (rather than "must be either") proves the
+    value was lowercased: an un-normalized "FRONTEND" would be rejected as an
+    invalid component instead.
+    """
+    result = runner.invoke(app, ["deps", "upgrade", component, "1.0.0"])
+    assert result.exit_code == 1
+    assert "Error: Frontend component is not enabled" in result.stdout
+    assert "Component must be either" not in result.stdout
+
+
+@pytest.mark.parametrize("component", ["FRONTEND", "Frontend", "FrOnTeNd"])
+def test_deps_sync_component_case_insensitive(
+    test_backend_only_project, bust_path_cache, runner, component
+):
+    """``deps sync`` normalizes the component name before the enabled check."""
+    result = runner.invoke(app, ["deps", "sync", component])
+    assert result.exit_code == 1
+    assert "Error: Frontend component is not enabled" in result.stdout
+    assert "Component must be either" not in result.stdout
+
+
+@pytest.mark.parametrize("component", ["BACKEND", "Backend", "BaCkEnD"])
+def test_deps_constraints_component_case_insensitive(
+    test_frontend_only_project, bust_path_cache, runner, component
+):
+    """``deps constraints`` accepts mixed-case ``backend`` past validation.
+
+    On a frontend-only project it stops at the uv-managed guard instead of the
+    invalid-component error, confirming the name was normalized.
+    """
+    result = runner.invoke(app, ["deps", "constraints", component])
+    assert result.exit_code == 0
+    assert "Component must be 'backend'." not in result.stdout
+
+
+@pytest.mark.parametrize("component", ["back", "end", "acken", "backendX"])
+def test_deps_constraints_rejects_substrings(
+    test_backend_only_project, bust_path_cache, runner, component
+):
+    """Substrings of "backend" must be rejected, not accepted.
+
+    Guards against the regression where ``component not in ("backend")`` did a
+    substring membership test, wrongly accepting e.g. "back" or "end".
+    """
+    result = runner.invoke(app, ["deps", "constraints", component])
+    assert result.exit_code == 1
+    assert "Component must be 'backend'." in result.stdout
+
+
 def test_backend_only_no_section_settings(
     test_backend_only_no_section_project, bust_path_cache
 ):


### PR DESCRIPTION
## Summary

Two related improvements to the `repoplone` dependency and release commands.

### Case-insensitive component names (#78)

`deps check` / `deps info` report component names capitalized (`Backend`,
`Frontend`), but the commands only accepted lowercase names as arguments — so
copy-pasting `Backend` into `deps upgrade Backend` failed. The component
argument is now normalized to lowercase in `deps upgrade`, `deps sync` and
`deps constraints`.

While here, fixed a latent bug in `deps constraints` where
`component not in ("backend")` performed a substring membership test (wrongly
accepting `back`, `end`, …) instead of an equality check, and refactored
`deps check` to iterate the shared `UPGRADE_FUNC` mapping.

### Restartable releases via `--start-step` (#79)

Sometimes errors happen mid-release (a failed publish, a network glitch, a
GitHub API hiccup). Until now the only option was to re-run `repoplone release`
from the very first step — wasteful, and unsafe for steps with side effects
(publishing, tagging).

`repoplone release <version> --start-step <step-id>` now restarts the pipeline
from a given step, skipping the earlier (already completed) ones:

- Earlier steps are **skipped**, not removed — the step counter still reflects
  the full pipeline (`01/08 … (skipped)`), and they are treated as successful.
- When the `version` step is skipped, the version supplied on the command line
  is **resolved and validated** in its place (segments expanded, versions
  already tagged in Git rejected); a concrete version becomes mandatory.
- Validation lives in two testable helpers: `resolve_start` (validates the
  start step against the project's *resolved* pipeline) and
  `resolve_skipped_version`.

## Testing

- New unit + integration tests for component case-insensitivity, the
  `constraints` substring-rejection regression, `resolve_start`,
  `resolve_skipped_version`, and the pipeline skip behaviour.
- Full suite: **421 passed**.
- `ruff format` + `ruff check` clean, `mypy src` clean.

Closes #78
Closes #79